### PR TITLE
[#154477526] Add sleep between requests in ExpectAllAppInstancesToBeReachable

### DIFF
--- a/smoke/runtime/runtime_test.go
+++ b/smoke/runtime/runtime_test.go
@@ -162,6 +162,8 @@ func ExpectAllAppInstancesToBeReachable(appUrl string, instances int, maxAttempt
 			sawAll = true
 			break
 		}
+
+		time.Sleep(time.Duration(5000/maxAttempts) * time.Millisecond)
 	}
 
 	Expect(sawAll).To(BeTrue(), fmt.Sprintf("Expected to hit all %d app instances in %d attempts, but didn't", instances, maxAttempts))


### PR DESCRIPTION
## What

In the "can be pushed, scaled and deleted" tests the application is upscaled to two instances. The tests wait until both application instances are in a running state and run up to 30 requests to check whether both instances get traffic.

The timing of these tests are really tight, as the route registration can be still pending even if the API returns a running state for the second instance and the requests are too quick (we are seeing only ~400ms for all 30 requests). In rare cases the tests fail although the route is eventually registered a little bit later (some hundreds of milliseconds).

We add some sleep between the requests, which adds an extra 5 seconds window for the new route registration to finish.

## How to review it

Review as part of https://github.com/alphagov/paas-cf/pull/1191

## Who can review it

Not @henrytk or @bandesz